### PR TITLE
Drop old versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/dependency-injection": "^2.3 || ^3.0",
-        "symfony/form": "^2.3 || ^3.0"
+        "symfony/dependency-injection": "^2.8 || ^3.0",
+        "symfony/form": "^2.8 || ^3.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },
     "autoload": {
         "psr-4": { "Sonata\\DatagridBundle\\": "" },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "symfony/dependency-injection": "^2.3 || ^3.0",
         "symfony/form": "^2.3 || ^3.0"
     },


### PR DESCRIPTION
I am targetting this branch, because bumping versions of php / symfony is considered major.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for PHP 5.3 through 5.5 was removed
- Support for Symfony 2.3 through 2.7 was removed

```

## Subject

This prepares the next major release.
