### PR TITLE
use RuntimeException instead of RunTimeException

### DIFF
--- a/Filter/BaseFilter.php
+++ b/Filter/BaseFilter.php
@@ -11,9 +11,6 @@
 
 namespace Sonata\DatagridBundle\Filter;
 
-/**
- * Class BaseFilter.
- */
 abstract class BaseFilter implements FilterInterface
 {
     /**

--- a/Filter/BaseFilter.php
+++ b/Filter/BaseFilter.php
@@ -124,7 +124,7 @@ abstract class BaseFilter implements FilterInterface
         $fieldName = $this->getOption('field_name');
 
         if (!$fieldName) {
-            throw new \RunTimeException(sprintf('The option `field_name` must be set for field : `%s`', $this->getName()));
+            throw new \RuntimeException(sprintf('The option `field_name` must be set for field : `%s`', $this->getName()));
         }
 
         return $fieldName;

--- a/Pager/Doctrine/Pager.php
+++ b/Pager/Doctrine/Pager.php
@@ -17,7 +17,7 @@ use Sonata\DatagridBundle\Pager\BasePager;
 /**
  * Doctrine pager class.
  *
- * @author     Jonathan H. Wage <jonwage@gmail.com>
+ * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 class Pager extends BasePager
 {

--- a/ProxyQuery/Doctrine/ProxyQuery.php
+++ b/ProxyQuery/Doctrine/ProxyQuery.php
@@ -16,9 +16,7 @@ use Doctrine\ORM\QueryBuilder;
 use Sonata\DatagridBundle\ProxyQuery\BaseProxyQuery;
 
 /**
- * Class ProxyQuery.
- *
- * This is the Doctrine proxy query class
+ * This is the Doctrine proxy query class.
  */
 class ProxyQuery extends BaseProxyQuery
 {

--- a/SonataDatagridBundle.php
+++ b/SonataDatagridBundle.php
@@ -13,9 +13,6 @@ namespace Sonata\DatagridBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * Class SonataDatagridBundle.
- */
 class SonataDatagridBundle extends Bundle
 {
 }

--- a/Tests/Filter/BaseFilterTest.php
+++ b/Tests/Filter/BaseFilterTest.php
@@ -94,7 +94,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RunTimeException
+     * @expectedException \RuntimeException
      */
     public function testExceptionOnNonDefinedFieldName()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDatagridBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- use `\RuntimeException` instead of `\RunTimeException`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests