### PR TITLE
Added count method to PagerInterface

### DIFF
--- a/Pager/BasePager.php
+++ b/Pager/BasePager.php
@@ -19,7 +19,7 @@ use Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface;
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-abstract class BasePager implements \Iterator, \Countable, \Serializable, PagerInterface
+abstract class BasePager implements \Serializable, PagerInterface
 {
     /**
      * @var int
@@ -298,9 +298,7 @@ abstract class BasePager implements \Iterator, \Countable, \Serializable, PagerI
     }
 
     /**
-     * Returns the last page number.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getLastPage()
     {
@@ -308,9 +306,7 @@ abstract class BasePager implements \Iterator, \Countable, \Serializable, PagerI
     }
 
     /**
-     * Returns the current page.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getPage()
     {
@@ -318,9 +314,7 @@ abstract class BasePager implements \Iterator, \Countable, \Serializable, PagerI
     }
 
     /**
-     * Returns the next page.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getNextPage()
     {
@@ -328,9 +322,7 @@ abstract class BasePager implements \Iterator, \Countable, \Serializable, PagerI
     }
 
     /**
-     * Returns the previous page.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getPreviousPage()
     {

--- a/Pager/PagerInterface.php
+++ b/Pager/PagerInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\DatagridBundle\Pager;
 
-interface PagerInterface
+interface PagerInterface extends \Countable
 {
     /**
      * Initialize the Pager.
@@ -52,4 +52,11 @@ interface PagerInterface
      * @return array
      */
     public function getResults();
+
+    /**
+     * Returns the number of results.
+     *
+     * @return int
+     */
+    public function getCount();
 }

--- a/Pager/PagerInterface.php
+++ b/Pager/PagerInterface.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\DatagridBundle\Pager;
 
+use Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface;
+
 interface PagerInterface extends \Iterator, \Countable
 {
     /**
@@ -87,4 +89,195 @@ interface PagerInterface extends \Iterator, \Countable
      * @return int
      */
     public function getPreviousPage();
+
+    /**
+     * Returns the current pager's max link.
+     *
+     * @return int
+     */
+    public function getCurrentMaxLink();
+
+    /**
+     * Returns the current pager's max record limit.
+     *
+     * @return int
+     */
+    public function getMaxRecordLimit();
+
+    /**
+     * Sets the current pager's max record limit.
+     *
+     * @param int $limit
+     */
+    public function setMaxRecordLimit($limit);
+
+    /**
+     * Returns an array of page numbers to use in pagination links.
+     *
+     * @param int $nbLinks The maximum number of page numbers to return
+     *
+     * @return array
+     */
+    public function getLinks($nbLinks = null);
+
+    /**
+     * Returns true if the current query requires pagination.
+     *
+     * @return bool
+     */
+    public function haveToPaginate();
+
+    /**
+     * Returns the current cursor.
+     *
+     * @return int
+     */
+    public function getCursor();
+
+    /**
+     * Sets the current cursor.
+     *
+     * @param int $pos
+     */
+    public function setCursor($pos);
+
+    /**
+     * Returns an object by cursor position.
+     *
+     * @param int $pos
+     *
+     * @return mixed
+     */
+    public function getObjectByCursor($pos);
+
+    /**
+     * Returns the current object.
+     *
+     * @return mixed
+     */
+    public function getCurrent();
+
+    /**
+     * Returns the next object.
+     *
+     * @return mixed|null
+     */
+    public function getNext();
+
+    /**
+     * Returns the previous object.
+     *
+     * @return mixed|null
+     */
+    public function getPrevious();
+
+    /**
+     * Returns the first index on the current page.
+     *
+     * @return int
+     */
+    public function getFirstIndice();
+
+    /**
+     * Returns the last index on the current page.
+     *
+     * @return int
+     */
+    public function getLastIndice();
+
+    /**
+     * Returns the number of results.
+     *
+     * @return int
+     */
+    public function getNbResults();
+
+    /**
+     * Returns the maximum number of page numbers.
+     *
+     * @return int
+     */
+    public function getMaxPageLinks();
+
+    /**
+     * Sets the maximum number of page numbers.
+     *
+     * @param int $maxPageLinks
+     */
+    public function setMaxPageLinks($maxPageLinks);
+
+    /**
+     * Returns true if on the first page.
+     *
+     * @return bool
+     */
+    public function isFirstPage();
+
+    /**
+     * Returns true if on the last page.
+     *
+     * @return bool
+     */
+    public function isLastPage();
+
+    /**
+     * Returns the current pager's parameter holder.
+     *
+     * @return array
+     */
+    public function getParameters();
+
+    /**
+     * Returns a parameter.
+     *
+     * @param string $name
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public function getParameter($name, $default = null);
+
+    /**
+     * Checks whether a parameter has been set.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasParameter($name);
+
+    /**
+     * Sets a parameter.
+     *
+     * @param string $name
+     * @param mixed  $value
+     */
+    public function setParameter($name, $value);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized);
+
+    /**
+     * @return array
+     */
+    public function getCountColumn();
+
+    /**
+     * @param array $countColumn
+     *
+     * @return array
+     */
+    public function setCountColumn(array $countColumn);
+
+    /**
+     * @return ProxyQueryInterface
+     */
+    public function getQuery();
 }

--- a/Pager/PagerInterface.php
+++ b/Pager/PagerInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\DatagridBundle\Pager;
 
-interface PagerInterface extends \Countable
+interface PagerInterface extends \Iterator, \Countable
 {
     /**
      * Initialize the Pager.
@@ -54,9 +54,37 @@ interface PagerInterface extends \Countable
     public function getResults();
 
     /**
-     * Returns the number of results.
+     * Returns the first page number.
      *
      * @return int
      */
-    public function getCount();
+    public function getFirstPage();
+
+    /**
+     * Returns the last page number.
+     *
+     * @return int
+     */
+    public function getLastPage();
+
+    /**
+     * Returns the current page.
+     *
+     * @return int
+     */
+    public function getPage();
+
+    /**
+     * Returns the next page.
+     *
+     * @return int
+     */
+    public function getNextPage();
+
+    /**
+     * Returns the previous page.
+     *
+     * @return int
+     */
+    public function getPreviousPage();
 }

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,2 +1,6 @@
 UPGRADE FROM 2.x to 3.0
 =======================
+
+## Interfaces
+
+The `Pager/PagerInterface` implements `\Iterator` and `\Countable`.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -4,3 +4,4 @@ UPGRADE FROM 2.x to 3.0
 ## Interfaces
 
 The `Pager/PagerInterface` implements `\Iterator` and `\Countable`.
+All public methods of `Pager\BasePager` were moved to `Pager/PagerInterface`.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDatagridBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `\Countable` interface to `PagerInterface`
- Added `\Iterator` interface to `PagerInterface`
- Moved all public methods of `BasePager` to `PagerInterface`
```

## Subject

Added the interface to `PagerInterface` to return the total number of items.
