### PR TITLE
Fix phpunit deprecations

### DIFF
--- a/Tests/Datagrid/DatagridTest.php
+++ b/Tests/Datagrid/DatagridTest.php
@@ -14,6 +14,7 @@ namespace Sonata\DatagridBundle\Tests\Datagrid;
 use Sonata\DatagridBundle\Datagrid\Datagrid;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface;
+use Sonata\DatagridBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\FormBuilder;
 
 class TestEntity
@@ -23,7 +24,7 @@ class TestEntity
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class DatagridTest extends \PHPUnit_Framework_TestCase
+class DatagridTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var Datagrid
@@ -52,8 +53,8 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->query = $this->getMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
-        $this->pager = $this->getMock('Sonata\DatagridBundle\Pager\PagerInterface');
+        $this->query = $this->createMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
+        $this->pager = $this->createMock('Sonata\DatagridBundle\Pager\PagerInterface');
 
         $this->formTypes = array();
 
@@ -74,8 +75,8 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             }));
 
         // php 5.3 BC
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
         $this->formBuilder->expects($this->any())
             ->method('add')
@@ -111,7 +112,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->datagrid->hasFilter('foo'));
         $this->assertNull($this->datagrid->getFilter('foo'));
 
-        $filter = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -131,17 +132,17 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(array(), $this->datagrid->getFilters());
 
-        $filter1 = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
 
-        $filter2 = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
 
-        $filter3 = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter3 = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter3->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('baz'));
@@ -161,17 +162,17 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(array(), $this->datagrid->getFilters());
 
-        $filter1 = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
 
-        $filter2 = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
 
-        $filter3 = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter3 = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter3->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('baz'));
@@ -207,7 +208,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->datagrid->hasActiveFilters());
 
-        $filter1 = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -219,7 +220,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->datagrid->hasActiveFilters());
 
-        $filter2 = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
@@ -250,7 +251,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildPager()
     {
-        $filter1 = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter1 = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter1->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));
@@ -266,7 +267,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
 
         $this->datagrid->addFilter($filter1);
 
-        $filter2 = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter2 = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter2->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('bar'));
@@ -301,7 +302,7 @@ class DatagridTest extends \PHPUnit_Framework_TestCase
             '_sort_by' => 'name',
         ));
 
-        $filter = $this->getMock('Sonata\DatagridBundle\Filter\FilterInterface');
+        $filter = $this->createMock('Sonata\DatagridBundle\Filter\FilterInterface');
         $filter->expects($this->once())
             ->method('getName')
             ->will($this->returnValue('foo'));

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DatagridBundle\Tests\Helpers;
+
+/**
+ * This is helpers class for supporting old and new PHPUnit versions.
+ *
+ * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @author Anton Zlotnikov <exp.razor@gmail.com>
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMock($originalClassName)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($originalClassName);
+        }
+
+        return parent::getMock($originalClassName);
+    }
+}

--- a/Tests/Pager/BasePagerTest.php
+++ b/Tests/Pager/BasePagerTest.php
@@ -12,11 +12,12 @@
 namespace Sonata\DatagridBundle\Tests\Pager;
 
 use Sonata\DatagridBundle\Pager\BasePager;
+use Sonata\DatagridBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class BasePagerTest extends \PHPUnit_Framework_TestCase
+class BasePagerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var BasePager
@@ -137,7 +138,7 @@ class BasePagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetQuery()
     {
-        $query = $this->getMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
+        $query = $this->createMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
 
         $this->pager->setQuery($query);
         $this->assertEquals($query, $this->pager->getQuery());
@@ -359,7 +360,7 @@ class BasePagerTest extends \PHPUnit_Framework_TestCase
 
         $this->callMethod($this->pager, 'setNbResults', array(3));
 
-        $query = $this->getMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
+        $query = $this->createMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
 
         $query->expects($this->any())
             ->method('setFirstResult')
@@ -490,7 +491,7 @@ class BasePagerTest extends \PHPUnit_Framework_TestCase
 
         $this->callMethod($this->pager, 'setNbResults', array(3));
 
-        $query = $this->getMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
+        $query = $this->createMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
 
         $query->expects($this->any())
             ->method('setFirstResult')
@@ -551,7 +552,7 @@ class BasePagerTest extends \PHPUnit_Framework_TestCase
 
         $this->callMethod($this->pager, 'setNbResults', array(3));
 
-        $query = $this->getMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
+        $query = $this->createMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
 
         $query->expects($this->any())
             ->method('setFirstResult')

--- a/Tests/Pager/Doctrine/PagerTest.php
+++ b/Tests/Pager/Doctrine/PagerTest.php
@@ -12,11 +12,12 @@
 namespace Sonata\DatagridBundle\Tests\Pager\Doctrine;
 
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
+use Sonata\DatagridBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Romain Mouillard <romain.mouillard@gmail.com>
  */
-class PagerTest extends \PHPUnit_Framework_TestCase
+class PagerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var Pager
@@ -37,7 +38,7 @@ class PagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetResults()
     {
-        $query = $this->getMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
+        $query = $this->createMock('Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface');
 
         $object1 = new \stdClass();
         $object1->foo = 'bar1';


### PR DESCRIPTION
I am targetting this branch, because it is BC.
## Changelog
```markdown
### Fixed
- Deprecated `getMock` method replaced with `createMock`
```

PHPUnit 5.7.14
Before:
```
WARNINGS!
Tests: 60, Assertions: 237, Warnings: 16.
```
After:
```
OK (60 tests, 237 assertions)
```
