### PR TITLE
Drop support for PHP 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "symfony/dependency-injection": "^2.8 || ^3.0",
         "symfony/form": "^2.8 || ^3.0"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDatagridBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC break.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - Removed support for PHP 5
```

## Subject

Frist step for the next major release. Drop support for all PHP Version below 7.1
