### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
-        "symfony/dependency-injection": "^2.3 || ^3.0",
-        "symfony/form": "^2.3 || ^3.0"
+        "php": "^7.1",
+        "symfony/dependency-injection": "^2.8 || ^3.0",
+        "symfony/form": "^2.8 || ^3.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "autoload": {
         "psr-4": { "Sonata\\DatagridBundle\\": "src/" }

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -14,6 +14,7 @@ namespace Sonata\DatagridBundle\Datagrid;
 use Sonata\DatagridBundle\Filter\FilterInterface;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormInterface;
 
@@ -114,10 +115,10 @@ class Datagrid implements DatagridInterface
             $this->formBuilder->add($filter->getFormName(), $type, $options);
         }
 
-        $this->formBuilder->add('_sort_by', 'hidden');
-        $this->formBuilder->add('_sort_order', 'hidden');
-        $this->formBuilder->add('_page', 'hidden');
-        $this->formBuilder->add('_per_page', 'hidden');
+        $this->formBuilder->add('_sort_by', HiddenType::class);
+        $this->formBuilder->add('_sort_order', HiddenType::class);
+        $this->formBuilder->add('_page', HiddenType::class);
+        $this->formBuilder->add('_per_page', HiddenType::class);
 
         $this->form = $this->formBuilder->getForm();
         $this->form->submit($this->values);


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Changed
- Removed usage of old form type aliases

### Removed
- Support for old versions of php and Symfony.
```
