### PR TITLE
allow Symfony 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/dependency-injection": "^2.8 || ^3.2",
-        "symfony/form": "^2.8 || ^3.2"
+        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
+        "symfony/form": "^2.8 || ^3.2 || ^4.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDatagridBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs https://github.com/sonata-project/SonataUserBundle/pull/974

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Allow Symfony 4.0
```

## Subject

Looks like https://github.com/sonata-project/SonataUserBundle/pull/974 could be fixed by this PR.

## Error

``` 
Problem 1
    - Conclusion: don't install sonata-project/datagrid-bundle 2.3.0
    - Installation request for sonata-project/datagrid-bundle ^2.2.1 -> satisfiable by sonata-project/datagrid-bundle[2.2.1, 2.3.0].
    - Conclusion: don't install symfony/symfony v4.0.1
```

[Link to the failing build](https://travis-ci.org/sonata-project/SonataUserBundle/jobs/311422100)