### PR TITLE
Update all templates references to Twig namespaced syntax

### DIFF
--- a/src/Resources/views/Search/results.html.twig
+++ b/src/Resources/views/Search/results.html.twig
@@ -29,13 +29,13 @@
 </div>
 
 <div class="row text-center">
-    {% include 'SonataDatagridBundle:Search:pager.html.twig' %}
+    {% include '@SonataDatagrid/Search/pager.html.twig' %}
 </div>
 
 <div class="row">
     {% for product in results %}
         <div class="col-sm-4" itemscope itemtype="http://schema.org/Product">
-            {% include 'SonataProductBundle:Catalog:_product_grid.html.twig' %}
+            {% include '@SonataProduct/Catalog/_product_grid.html.twig' %}
         </div>
     {% endfor %}
 </div>


### PR DESCRIPTION
I am targeting this branch, because it is patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- All templates references are updated to twig namespaced syntax
```

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See https://github.com/sonata-project/dev-kit/issues/380 for details