### PR TITLE
prepare phpunit.xml.dist for dev-kit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,20 +13,13 @@
 >
     <testsuites>
         <testsuite name="DatagridBundle Test Suite">
-            <directory>./tests</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./tests/</directory>
-                <directory>./DataFixtures/</directory>
-                <directory>./Resources/</directory>
-                <directory>./vendor/</directory>
-                <directory>./coverage/</directory>
-            </exclude>
+            <directory suffix=".php">./src/</directory>
         </whitelist>
     </filter>
 


### PR DESCRIPTION
I am targeting this branch, because **no other branch available**.

Refs https://github.com/sonata-project/dev-kit/pull/370

## Changelog
```markdown
### Changed
- prepared `phpunit.xml.dist` for management via `dev-kit`
```

## Subject

To keep the diff small and don't ran into some problems, I will fix it manually to have the same version for the start.