### PR TITLE
Added constructor shortcuts

### DIFF
--- a/src/Pager/Doctrine/Pager.php
+++ b/src/Pager/Doctrine/Pager.php
@@ -13,6 +13,8 @@ namespace Sonata\DatagridBundle\Pager\Doctrine;
 
 use Doctrine\ORM\Query;
 use Sonata\DatagridBundle\Pager\BasePager;
+use Sonata\DatagridBundle\Pager\PagerInterface;
+use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 
 /**
  * Doctrine pager class.
@@ -79,5 +81,23 @@ class Pager extends BasePager
             $this->getQuery()->setFirstResult($offset);
             $this->getQuery()->setMaxResults($this->getMaxPerPage());
         }
+    }
+
+    /**
+     * Builds a pager for a given query builder.
+     *
+     * @param int $limit
+     * @param int $page
+     *
+     * @return PagerInterface
+     */
+    public static function create(QueryBuilder $builder, $limit, $page)
+    {
+        $pager = new self($limit);
+        $pager->setQuery(new ProxyQuery($builder));
+        $pager->setPage($page);
+        $pager->init();
+
+        return $pager;
     }
 }

--- a/src/Pager/Elastica/Pager.php
+++ b/src/Pager/Elastica/Pager.php
@@ -12,6 +12,8 @@
 namespace Sonata\DatagridBundle\Pager\Elastica;
 
 use Sonata\DatagridBundle\Pager\BasePager;
+use Sonata\DatagridBundle\Pager\PagerInterface;
+use Sonata\DatagridBundle\ProxyQuery\Elastica\ProxyQuery;
 
 /**
  * Elastica pager class.
@@ -72,5 +74,23 @@ class Pager extends BasePager
             $this->getQuery()->setFirstResult($offset);
             $this->getQuery()->setMaxResults($this->getMaxPerPage());
         }
+    }
+
+    /**
+     * Builds a pager for a given query builder.
+     *
+     * @param int $limit
+     * @param int $page
+     *
+     * @return PagerInterface
+     */
+    public static function create(QueryBuilder $builder, $limit, $page)
+    {
+        $pager = new self($limit);
+        $pager->setQuery(new ProxyQuery($builder));
+        $pager->setPage($page);
+        $pager->init();
+
+        return $pager;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDatagridBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Pager::create` method

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

This will reduce code duplication when you try to init a `Pager` with all required params.
