### PR TITLE
Deprecate unused results.html.twig template

### DIFF
--- a/src/Resources/views/Search/results.html.twig
+++ b/src/Resources/views/Search/results.html.twig
@@ -1,3 +1,5 @@
+{% sonata_template_deprecate 'none' %}
+
 <div class="row">
     <form name="search" method="get" action="{{ path(route) }}">
         <div class="row">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDatagridBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate `results.html.twig` template
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

This template contains logic of the ecommerce bundle and is unrelated to a general datagrid.