### PR TITLE
Cast float to int when last page in Pager is assigned.

### DIFF
--- a/src/Pager/BasePager.php
+++ b/src/Pager/BasePager.php
@@ -611,7 +611,7 @@ abstract class BasePager implements \Iterator, \Countable, \Serializable, PagerI
      */
     protected function setLastPage($page)
     {
-        $this->lastPage = $page;
+        $this->lastPage = (int) $page;
 
         if ($this->getPage() > $page) {
             $this->setPage($page);


### PR DESCRIPTION
## Subject

Variable `lastPage` can be float. It was a problem with identical comparision `(===)`.

I am targeting this branch, because it is a patch.

## Changelog

```markdown
### Fixed
- Cast float to int when last page in Pager is assigned

