### PR TITLE
Drop old versions of Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/config": "^2.8 || ^3.2 || ^4.0",
-        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
-        "symfony/form": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0"
+        "symfony/config": "^3.4 || ^4.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0",
+        "symfony/form": "^3.4 || ^4.0",
+        "symfony/http-kernel": "^3.4 || ^4.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",


### PR DESCRIPTION
They are not supported anymore.

I am targeting this branch, because this is BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for symfony < 3.4
```