### PR TITLE
cast getSingleScalarResult() result to integer for Pager::computeNbResult

### DIFF
--- a/src/Pager/Doctrine/Pager.php
+++ b/src/Pager/Doctrine/Pager.php
@@ -45,7 +45,7 @@ final class Pager extends BasePager
             current($this->getCountColumn())
         ));
 
-        return $countQuery->getQuery()->getSingleScalarResult();
+        return (int) $countQuery->getQuery()->getSingleScalarResult();
     }
 
     public function getResults($hydrationMode = Query::HYDRATE_OBJECT): ?array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Error: `Return value of Sonata\DatagridBundle\Pager\Doctrine\Pager::computeNbResult() must be of the type integer, string returned` when calls Pager::computeNbResult

