### PR TITLE
Use FQCN type for default filter type

### DIFF
--- a/src/Filter/BaseFilter.php
+++ b/src/Filter/BaseFilter.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\DatagridBundle\Filter;
 
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
 abstract class BaseFilter implements FilterInterface
 {
     /**
@@ -81,7 +83,7 @@ abstract class BaseFilter implements FilterInterface
 
     public function getFieldType(): string
     {
-        return $this->getOption('field_type', 'text');
+        return $this->getOption('field_type', TextType::class);
     }
 
     public function getFieldOptions(): array

--- a/tests/Filter/BaseFilterTest.php
+++ b/tests/Filter/BaseFilterTest.php
@@ -16,6 +16,7 @@ namespace Sonata\DatagridBundle\Tests\Filter;
 use PHPUnit\Framework\TestCase;
 use Sonata\DatagridBundle\Filter\BaseFilter;
 use Sonata\DatagridBundle\ProxyQuery\ProxyQueryInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class FilterTest_Filter extends BaseFilter
 {
@@ -46,7 +47,7 @@ class FilterTest extends TestCase
     {
         $filter = new FilterTest_Filter();
 
-        $this->assertSame('text', $filter->getFieldType());
+        $this->assertSame(TextType::class, $filter->getFieldType());
         $this->assertSame(['required' => false], $filter->getFieldOptions());
         $this->assertNull($filter->getLabel());
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDatagridBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDatagridBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed default filter type should be FQCN 
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
