### PR TITLE
Add methods to be used by AdminBundle

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -189,6 +189,18 @@ final class Datagrid implements DatagridInterface
         return false;
     }
 
+    public function hasDisplayableFilters(): bool
+    {
+        foreach ($this->filters as $name => $filter) {
+            $showFilter = $filter->getOption('show_filter', null);
+            if (($filter->isActive() && null === $showFilter) || (true === $showFilter)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function getQuery(): ProxyQueryInterface
     {
         return $this->query;

--- a/src/Datagrid/DatagridInterface.php
+++ b/src/Datagrid/DatagridInterface.php
@@ -50,4 +50,6 @@ interface DatagridInterface
     public function removeFilter(string $name): void;
 
     public function hasActiveFilters(): bool;
+
+    public function hasDisplayableFilters(): bool;
 }

--- a/src/Filter/BaseFilter.php
+++ b/src/Filter/BaseFilter.php
@@ -91,6 +91,20 @@ abstract class BaseFilter implements FilterInterface
         return $this->getOption('field_options', ['required' => false]);
     }
 
+    public function getFieldOption(string $name, $default = null)
+    {
+        if (isset($this->options['field_options'][$name]) && \is_array($this->options['field_options'])) {
+            return $this->options['field_options'][$name];
+        }
+
+        return $default;
+    }
+
+    public function setFieldOption(string $name, $value): void
+    {
+        $this->options['field_options'][$name] = $value;
+    }
+
     public function getLabel(): ?string
     {
         return $this->getOption('label');
@@ -110,6 +124,33 @@ abstract class BaseFilter implements FilterInterface
         }
 
         return $fieldName;
+    }
+
+    public function getParentAssociationMappings(): array
+    {
+        return $this->getOption('parent_association_mappings', []);
+    }
+
+    public function getFieldMapping(): array
+    {
+        $fieldMapping = $this->getOption('field_mapping');
+
+        if (!$fieldMapping) {
+            throw new \RuntimeException(sprintf('The option `field_mapping` must be set for field: `%s`', $this->getName()));
+        }
+
+        return $fieldMapping;
+    }
+
+    public function getAssociationMapping(): array
+    {
+        $associationMapping = $this->getOption('association_mapping');
+
+        if (!$associationMapping) {
+            throw new \RuntimeException(sprintf('The option `association_mapping` must be set for field: `%s`', $this->getName()));
+        }
+
+        return $associationMapping;
     }
 
     public function setOptions(array $options): void

--- a/src/Filter/FilterFactoryInterface.php
+++ b/src/Filter/FilterFactoryInterface.php
@@ -15,8 +15,5 @@ namespace Sonata\DatagridBundle\Filter;
 
 interface FilterFactoryInterface
 {
-    /**
-     * @return mixed
-     */
-    public function create(string $name, string $type, array $options = []);
+    public function create(string $name, string $type, array $options = []): FilterInterface;
 }

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -58,7 +58,34 @@ interface FilterInterface
 
     public function getFieldName(): string;
 
+    /**
+     * @return array<string, string> array of mappings
+     */
+    public function getParentAssociationMappings(): array;
+
+    /**
+     * @return array<string, string> field mapping
+     */
+    public function getFieldMapping(): array;
+
+    /**
+     * @return array<string, string>  association mapping
+     */
+    public function getAssociationMapping(): array;
+
     public function getFieldOptions(): array;
+
+    /**
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getFieldOption(string $name, $default = null);
+
+    /**
+     * @param mixed $value
+     */
+    public function setFieldOption(string $name, $value): void;
 
     public function getFieldType(): string;
 

--- a/src/ProxyQuery/ProxyQueryInterface.php
+++ b/src/ProxyQuery/ProxyQueryInterface.php
@@ -28,25 +28,13 @@ interface ProxyQueryInterface
      */
     public function execute(array $params = [], ?int $hydrationMode = null);
 
-    /**
-     * @param mixed $sortBy
-     */
-    public function setSortBy($sortBy): self;
+    public function setSortBy(array $parentAssociationMappings, array $fieldMapping): self;
 
-    /**
-     * @return mixed
-     */
-    public function getSortBy();
+    public function getSortBy(): ?string;
 
-    /**
-     * @param mixed $sortOrder
-     */
-    public function setSortOrder($sortOrder): self;
+    public function setSortOrder(string $sortOrder): self;
 
-    /**
-     * @return mixed
-     */
-    public function getSortOrder();
+    public function getSortOrder(): ?string;
 
     public function setFirstResult(?int $firstResult): self;
 
@@ -57,4 +45,8 @@ interface ProxyQueryInterface
     public function getMaxResults(): ?int;
 
     public function getResults(): array;
+
+    public function getUniqueParameterId(): int;
+
+    public function entityJoin(array $associationMappings): string;
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC-break.

The AdminBundle and the DatagridBundle has a lot of classes in common.
I would like that the AdminBundle requires the DatagridBundle and use his classes.

But currently some methods are missing in the interface, so I added them.

## Changelog

```markdown
### Added
- Added hasDisplayableFilters in DatagridInterface and Datagrid
- Added getFieldOption, setFieldOption, getParentAssociationMappings, getFieldMapping, getAssociationMapping in FilterInterface and BaseFilter
- Added getUniqueParameterId, entityJoin in ProxyQueryInterface and BaseProxyQuery

### Changed
- BaseProxyQuery::setSortBy and ProxyQueryInterface::setSortBy signature
```